### PR TITLE
Add objects tied to VersionGroup to VersionGroup object

### DIFF
--- a/lib/poke_api/version_group.rb
+++ b/lib/poke_api/version_group.rb
@@ -2,8 +2,12 @@ module PokeApi
   # VersionGroup object handling all data fetched from /version_group
   class VersionGroup < NamedApiResource
     attr_reader :id,
+                :generation,
+                :move_learn_methods,
                 :name,
                 :order,
+                :pokedexes,
+                :regions,
                 :url,
                 :versions
 

--- a/spec/unit/poke_api/version_group_spec.rb
+++ b/spec/unit/poke_api/version_group_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe PokeApi::VersionGroup, :vcr do
       expect(version_group.name).to eq('red-blue')
       expect(version_group.order).to eq(1)
       expect(version_group.versions.first.class).to eq(PokeApi::Version)
+      # expect(version_group.generation.class).to eq(PokeApi::Generation)
+      expect(version_group.move_learn_methods.first.class).to eq(PokeApi::MoveLearnMethod)
+      expect(version_group.pokedexes.first.class).to eq(PokeApi::Pokedex)
+      expect(version_group.regions.first.class).to eq(PokeApi::Region)
     end
   end
 end


### PR DESCRIPTION
Closes issue #14 

Added `:generation`, `:move_learn_methods`, `:pokedexes`, and `:regions` to `PokeApi::VersionGroup`