### PR TITLE
Move attr_reader :id, :name, :url to NamedApiResource

### DIFF
--- a/lib/poke_api/location.rb
+++ b/lib/poke_api/location.rb
@@ -1,13 +1,10 @@
 module PokeApi
   # Location object handling all data fetched from /location
   class Location < NamedApiResource
-    attr_reader :id,
-                :areas,
-                :name,
+    attr_reader :areas,
                 :names,
                 :region,
-                :game_indices,
-                :url
+                :game_indices
 
     def initialize(data)
       assign_data(data)

--- a/lib/poke_api/location_area.rb
+++ b/lib/poke_api/location_area.rb
@@ -1,14 +1,11 @@
 module PokeApi
   # LocationArea object handling all data fetched from /location-area
   class LocationArea < NamedApiResource
-    attr_reader :id,
-                :encounter_method_rates,
+    attr_reader :encounter_method_rates,
                 :game_index,
                 :location,
-                :name,
                 :names,
-                :pokemon_encounters,
-                :url
+                :pokemon_encounters
 
     def initialize(data)
       assign_data(data)

--- a/lib/poke_api/location_area/encounter_method_rate.rb
+++ b/lib/poke_api/location_area/encounter_method_rate.rb
@@ -1,7 +1,7 @@
 module PokeApi
   class LocationArea
     # EncounterMethodRate object handling encounter_method_rate data fetched from /location-area
-    class EncounterMethodRate < NamedApiResource
+    class EncounterMethodRate
       include AssignmentHelpers
 
       attr_reader :encounter_method,

--- a/lib/poke_api/move_learn_method.rb
+++ b/lib/poke_api/move_learn_method.rb
@@ -1,9 +1,7 @@
 module PokeApi
   # MoveLearnMethod object handling all data fetched from /move-learn-method
   class MoveLearnMethod < NamedApiResource
-    attr_reader :id,
-                :name,
-                :names,
+    attr_reader :names,
                 :descriptions,
                 :version_groups
 

--- a/lib/poke_api/named_api_resource.rb
+++ b/lib/poke_api/named_api_resource.rb
@@ -1,6 +1,8 @@
 module PokeApi
   # Base class with shared methods for all Named API Resources
   class NamedApiResource
+    attr_reader :id, :name, :url
+
     def get
       return if id
 

--- a/lib/poke_api/pokedex.rb
+++ b/lib/poke_api/pokedex.rb
@@ -1,13 +1,10 @@
 module PokeApi
   # Pokdex object handling all data fetched from /pokedex
   class Pokedex < NamedApiResource
-    attr_reader :id,
-                :is_main_series,
-                :name,
+    attr_reader :is_main_series,
                 :names,
                 :pokemon_entries,
                 :region,
-                :url,
                 :version_groups
 
     def initialize(data)

--- a/lib/poke_api/pokemon.rb
+++ b/lib/poke_api/pokemon.rb
@@ -1,17 +1,15 @@
 module PokeApi
   # Pokemon object handling all data fetched from /pokemon
-  class Pokemon
+  class Pokemon < NamedApiResource
     attr_reader :abilities,
                 :base_experience,
                 :forms,
                 :game_indices,
                 :height,
                 :held_items,
-                :id,
                 :is_default,
                 :location_area_encounters,
                 :moves,
-                :name,
                 :order,
                 :species,
                 :sprites,
@@ -20,13 +18,7 @@ module PokeApi
                 :weight
 
     def initialize(data)
-      @base_experience = data[:base_experience]
-      @height = data[:height]
-      @id = data[:id]
-      @is_default = data[:is_default]
-      @name = data[:name]
-      @order = data[:order]
-      @weight = data[:weight]
+      assign_data(data)
     end
   end
 end

--- a/lib/poke_api/region.rb
+++ b/lib/poke_api/region.rb
@@ -1,9 +1,7 @@
 module PokeApi
   # Region object handling all data fetched from /region
   class Region < NamedApiResource
-    attr_reader :id,
-                :locations,
-                :name,
+    attr_reader :locations,
                 :names,
                 :main_generation,
                 :pokedexes,

--- a/lib/poke_api/utility/language.rb
+++ b/lib/poke_api/utility/language.rb
@@ -2,13 +2,10 @@ module PokeApi
   module Utility
     # Utility Language object used by several PokeApi endpoints
     class Language < NamedApiResource
-      attr_reader :id,
-                  :iso3166,
+      attr_reader :iso3166,
                   :iso639,
-                  :name,
                   :names,
-                  :official,
-                  :url
+                  :official
 
       def initialize(data)
         assign_data(data)

--- a/lib/poke_api/version.rb
+++ b/lib/poke_api/version.rb
@@ -1,10 +1,7 @@
 module PokeApi
   # Version object handling all data fetched from /version
   class Version < NamedApiResource
-    attr_reader :id,
-                :name,
-                :names,
-                :url,
+    attr_reader :names,
                 :version_group
 
     def initialize(data)

--- a/lib/poke_api/version_group.rb
+++ b/lib/poke_api/version_group.rb
@@ -1,14 +1,11 @@
 module PokeApi
   # VersionGroup object handling all data fetched from /version_group
   class VersionGroup < NamedApiResource
-    attr_reader :id,
-                :generation,
+    attr_reader :generation,
                 :move_learn_methods,
-                :name,
                 :order,
                 :pokedexes,
                 :regions,
-                :url,
                 :versions
 
     def initialize(data)


### PR DESCRIPTION
Closes issue #31 
Refactor shared attr_readers (`:id`, `:name`, `:url`) to parent class NamedApiResource.