### PR TITLE
Add PokeApi::EncounterCondition object and tests

### DIFF
--- a/lib/config/setup.rb
+++ b/lib/config/setup.rb
@@ -7,6 +7,7 @@ require "#{path}/../utils/assignment_helpers"
 require "#{path}/../poke_api/named_api_resource"
 
 require "#{path}/../poke_api/encounter_condition_value"
+require "#{path}/../poke_api/encounter_condition"
 require "#{path}/../poke_api/encounter_method"
 require "#{path}/../poke_api/location_area"
 require "#{path}/../poke_api/location_area/encounter_method_rate"

--- a/lib/poke_api/encounter_condition.rb
+++ b/lib/poke_api/encounter_condition.rb
@@ -1,0 +1,11 @@
+module PokeApi
+  # EncounterCondition object handling all data fetched from /encounter-condition
+  class EncounterCondition < NamedApiResource
+    attr_reader :names,
+                :values
+
+    def initialize(data)
+      assign_data(data)
+    end
+  end
+end

--- a/lib/utils/constants.rb
+++ b/lib/utils/constants.rb
@@ -1,6 +1,7 @@
 BASE_URI = 'https://pokeapi.co/api/v2/'.freeze
 ENDPOINTS = {
   encounter_condition_value: 'encounter-condition-value/',
+  encounter_condition: 'encounter-condition/',
   encounter_method: 'encounter-method/',
   location_area: 'location-area/',
   location: 'location/',
@@ -12,6 +13,7 @@ ENDPOINTS = {
   version_group: 'version-group/'
 }.freeze
 ENDPOINT_OBJECTS = {
+  condition: PokeApi::EncounterCondition,
   descriptions: PokeApi::Common::Description,
   encounter_details: PokeApi::Common::Encounter,
   encounter_method: PokeApi::EncounterMethod,

--- a/spec/cassettes/PokeApi_EncounterCondition/_initialize/creates_a_EncounterCondition_object_from_raw_json_data.yml
+++ b/spec/cassettes/PokeApi_EncounterCondition/_initialize/creates_a_EncounterCondition_object_from_raw_json_data.yml
@@ -1,0 +1,71 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://pokeapi.co/api/v2/encounter-condition/1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - pokeapi.co
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 09 Apr 2019 22:59:50 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=df6f89b948ef4bbfeb190754411b12eb51554850790; expires=Wed, 08-Apr-20
+        22:59:50 GMT; path=/; domain=.pokeapi.co; HttpOnly; Secure
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - public, max-age=86400, s-maxage=86400
+      Etag:
+      - W/"1de-2x4Ra3HNdeQbJyfg5Z2Ef8Puoj4"
+      Function-Execution-Id:
+      - kvi090gb0pdz
+      X-Powered-By:
+      - Express
+      X-Cloud-Trace-Context:
+      - 6e6099cec9ad430b64afb21af200ea43;o=1
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-bur17540-BUR
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1554850790.326150,VS0,VE382
+      Vary:
+      - accept-encoding, x-fh-requested-host, cookie, authorization
+      Cf-Cache-Status:
+      - MISS
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4c5017ff3f09784a-LAX
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":1,"name":"swarm","names":[{"language":{"name":"fr","url":"https://pokeapi.co/api/v2/language/5/"},"name":"Essaim"},{"language":{"name":"de","url":"https://pokeapi.co/api/v2/language/6/"},"name":"Schwarm"},{"language":{"name":"en","url":"https://pokeapi.co/api/v2/language/9/"},"name":"Swarm"}],"values":[{"name":"swarm-yes","url":"https://pokeapi.co/api/v2/encounter-condition-value/1/"},{"name":"swarm-no","url":"https://pokeapi.co/api/v2/encounter-condition-value/2/"}]}'
+    http_version: 
+  recorded_at: Tue, 09 Apr 2019 22:59:50 GMT
+recorded_with: VCR 4.0.0

--- a/spec/unit/poke-api-v2_spec.rb
+++ b/spec/unit/poke-api-v2_spec.rb
@@ -49,6 +49,10 @@ RSpec.describe PokeApi, :vcr  do
         expect(ENDPOINTS[:encounter_condition_value]).to eq('encounter-condition-value/')
       end
 
+      it 'sets correct :encounter_condition value' do
+        expect(ENDPOINTS[:encounter_condition]).to eq('encounter-condition/')
+      end
+
       it 'sets correct :encounter_method value' do
         expect(ENDPOINTS[:encounter_method]).to eq('encounter-method/')
       end
@@ -87,6 +91,10 @@ RSpec.describe PokeApi, :vcr  do
     end
 
     context 'ENDPOINT_OBJECTS' do
+      it 'sets correct :condition value' do
+        expect(ENDPOINT_OBJECTS[:condition]).to eq(PokeApi::EncounterCondition)
+      end
+
       it 'sets correct :descriptions value' do
         expect(ENDPOINT_OBJECTS[:descriptions]).to eq(PokeApi::Common::Description)
       end

--- a/spec/unit/poke_api/common/encounter_spec.rb
+++ b/spec/unit/poke_api/common/encounter_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe PokeApi::Common::Encounter do
       expect(encounter.min_level).to eq(20)
       expect(encounter.max_level).to eq(30)
       expect(encounter.condition_values.first.class).to eq(PokeApi::EncounterConditionValue)
-      expect(encounter.method.class).to eq( PokeApi::EncounterMethod)
+      expect(encounter.method.class).to eq(PokeApi::EncounterMethod)
     end
   end
 end

--- a/spec/unit/poke_api/encounter_condition_spec.rb
+++ b/spec/unit/poke_api/encounter_condition_spec.rb
@@ -1,0 +1,14 @@
+RSpec.describe PokeApi::EncounterCondition, :vcr do
+  describe '#initialize' do
+    it 'creates a EncounterCondition object from raw json data' do
+      raw_data = Fetcher.call(:encounter_condition, 1)
+      encounter = PokeApi::EncounterCondition.new(raw_data)
+
+      expect(encounter.class).to eq(PokeApi::EncounterCondition)
+      expect(encounter.id).to eq(1)
+      expect(encounter.name).to eq('swarm')
+      expect(encounter.names.first.class).to eq(PokeApi::Common::Name)
+      expect(encounter.values.first.class).to eq(PokeApi::EncounterConditionValue)
+    end
+  end
+end

--- a/spec/unit/poke_api/encounter_condition_value_spec.rb
+++ b/spec/unit/poke_api/encounter_condition_value_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe PokeApi::EncounterConditionValue, :vcr do
       expect(em.name).to eq('swarm-yes')
       expect(em.names.last.name).to eq('During a swarm')
       expect(em.names.last.language.name).to eq('en')
-      # expect(em.condition.class).to eq(PokeApi::EncounterCondition)
+      expect(em.condition.class).to eq(PokeApi::EncounterCondition)
     end
   end
 end


### PR DESCRIPTION
Closes issue #46 

- Adds `PokeApi::EncounterCondition` object to handle data fetched from `/api/v2/encounter-condition/{id or name}`
- Adds tests for `PokeApi::EncounterCondition` and uncomment tests depending on object