### PR TITLE
Fix typo in constant name in Symbol monkey-patch

### DIFF
--- a/lib/utils/monkey_patch/symbol.rb
+++ b/lib/utils/monkey_patch/symbol.rb
@@ -1,6 +1,6 @@
 # Monkey patch Symbol class for specific key matching methods
 class Symbol
-  SPECIAL_SIGNULAR = {
+  SPECIAL_SINGULAR = {
     abilities: :ability,
     areas: :location_area,
     berries: :berry,
@@ -8,6 +8,6 @@ class Symbol
   }.freeze
 
   def singularize
-    SPECIAL_SIGNULAR[self] || to_s.chop.to_sym
+    SPECIAL_SINGULAR[self] || to_s.chop.to_sym
   end
 end


### PR DESCRIPTION
Just a quick fix for a small typo spotted while reading the code.